### PR TITLE
Bind fetch to window on browser targets

### DIFF
--- a/dist/index.browser-module.js
+++ b/dist/index.browser-module.js
@@ -23,7 +23,8 @@ class Hash extends Transform {
         let error = null;
         try {
             this.update(chunk, encoding);
-        } catch (err) {
+        }
+        catch (err) {
             error = err;
         }
         callback(error);
@@ -32,7 +33,8 @@ class Hash extends Transform {
         let error = null;
         try {
             this.push(this.digest());
-        } catch (err) {
+        }
+        catch (err) {
             error = err;
         }
         callback(error);
@@ -46,7 +48,7 @@ class Hash extends Transform {
         const blockSize = this._blockSize;
         const length = data.length;
         let accum = this._len;
-        for (let offset = 0; offset < length; ) {
+        for (let offset = 0; offset < length;) {
             const assigned = accum % blockSize;
             const remainder = Math.min(length - offset, blockSize - assigned);
             for (let i = 0; i < remainder; i++) {
@@ -76,17 +78,20 @@ class Hash extends Transform {
             if (this._bigEndian) {
                 this._block.writeUInt32BE(0, this._blockSize - 8);
                 this._block.writeUInt32BE(bits, this._blockSize - 4);
-            } else {
+            }
+            else {
                 this._block.writeUInt32LE(bits, this._blockSize - 8);
                 this._block.writeUInt32LE(0, this._blockSize - 4);
             }
-        } else {
+        }
+        else {
             const lowBits = (bits & 0xffffffff) >>> 0;
             const highBits = (bits - lowBits) / 0x100000000;
             if (this._bigEndian) {
                 this._block.writeUInt32BE(highBits, this._blockSize - 8);
                 this._block.writeUInt32BE(lowBits, this._blockSize - 4);
-            } else {
+            }
+            else {
                 this._block.writeUInt32LE(lowBits, this._blockSize - 8);
                 this._block.writeUInt32LE(highBits, this._blockSize - 4);
             }
@@ -822,7 +827,8 @@ function createHash(alg) {
     const HashImp = HASH_IMPLEMENTATIONS.get(alg);
     if (HashImp) {
         return new HashImp();
-    } else {
+    }
+    else {
         throw new Error('Unsupported hash algorithm: ' + alg);
     }
 }
@@ -852,7 +858,8 @@ class Hmac extends Transform {
             key = createHash(alg)
                 .update(key)
                 .digest();
-        } else if (key.length < blocksize) {
+        }
+        else if (key.length < blocksize) {
             key = Buffer.concat([key, ZEROS], blocksize);
         }
         this._ipad = Buffer.alloc(blocksize);
@@ -867,9 +874,11 @@ class Hmac extends Transform {
         let err;
         try {
             this.update(data, enc);
-        } catch (e) {
+        }
+        catch (e) {
             err = e;
-        } finally {
+        }
+        finally {
             next(err);
         }
     }
@@ -877,7 +886,8 @@ class Hmac extends Transform {
         let err;
         try {
             this.push(this._final());
-        } catch (e) {
+        }
+        catch (e) {
             err = e;
         }
         done(err);
@@ -905,7 +915,8 @@ class Hmac extends Transform {
 let root;
 if (typeof window !== 'undefined') {
     root = window;
-} else if (typeof global !== 'undefined') {
+}
+else if (typeof global !== 'undefined') {
     root = global;
 }
 function randomBytes(size) {
@@ -921,18 +932,8 @@ function getHashes() {
 function createHmac(alg, key) {
     return new Hmac(alg.toLowerCase(), key);
 }
-const nativeFetch = fetch;
+const nativeFetch = fetch.bind(window);
 const nativeWS = WebSocket;
 const nativeRTCPeerConnection = root.RTCPeerConnection;
 
-export {
-    Hash,
-    Hmac,
-    nativeRTCPeerConnection as RTCPeerConnection,
-    nativeWS as WebSocket,
-    createHash,
-    createHmac,
-    nativeFetch as fetch,
-    getHashes,
-    randomBytes
-};
+export { Hash, Hmac, nativeRTCPeerConnection as RTCPeerConnection, nativeWS as WebSocket, createHash, createHmac, nativeFetch as fetch, getHashes, randomBytes };

--- a/dist/index.browser.d.ts
+++ b/dist/index.browser.d.ts
@@ -14,11 +14,4 @@ declare const nativeWS: {
     readonly OPEN: number;
 };
 declare const nativeRTCPeerConnection: RTCPeerConnection | undefined;
-export {
-    createHash,
-    Hash,
-    Hmac,
-    nativeFetch as fetch,
-    nativeWS as WebSocket,
-    nativeRTCPeerConnection as RTCPeerConnection
-};
+export { createHash, Hash, Hmac, nativeFetch as fetch, nativeWS as WebSocket, nativeRTCPeerConnection as RTCPeerConnection };

--- a/dist/index.browser.js
+++ b/dist/index.browser.js
@@ -1,15 +1,16 @@
-'use strict';
-Object.defineProperty(exports, '__esModule', { value: true });
-const tslib_1 = require('tslib');
-const createHash_1 = tslib_1.__importStar(require('./crypto/createHash'));
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const tslib_1 = require("tslib");
+const createHash_1 = tslib_1.__importStar(require("./crypto/createHash"));
 exports.createHash = createHash_1.default;
 exports.Hash = createHash_1.Hash;
-const Hmac_1 = tslib_1.__importDefault(require('./crypto/Hmac'));
+const Hmac_1 = tslib_1.__importDefault(require("./crypto/Hmac"));
 exports.Hmac = Hmac_1.default;
 let root;
 if (typeof window !== 'undefined') {
     root = window;
-} else if (typeof global !== 'undefined') {
+}
+else if (typeof global !== 'undefined') {
     root = global;
 }
 function randomBytes(size) {
@@ -28,7 +29,7 @@ function createHmac(alg, key) {
     return new Hmac_1.default(alg.toLowerCase(), key);
 }
 exports.createHmac = createHmac;
-const nativeFetch = fetch;
+const nativeFetch = fetch.bind(window);
 exports.fetch = nativeFetch;
 const nativeWS = WebSocket;
 exports.WebSocket = nativeWS;

--- a/dist/index.node.js
+++ b/dist/index.node.js
@@ -1,11 +1,11 @@
-'use strict';
-Object.defineProperty(exports, '__esModule', { value: true });
-const tslib_1 = require('tslib');
-const node_fetch_1 = tslib_1.__importDefault(require('node-fetch'));
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const tslib_1 = require("tslib");
+const node_fetch_1 = tslib_1.__importDefault(require("node-fetch"));
 exports.fetch = node_fetch_1.default;
-const ws_1 = tslib_1.__importDefault(require('ws'));
+const ws_1 = tslib_1.__importDefault(require("ws"));
 exports.WebSocket = ws_1.default;
-const crypto_1 = require('crypto');
+const crypto_1 = require("crypto");
 exports.Hash = crypto_1.Hash;
 exports.Hmac = crypto_1.Hmac;
 const ianaNames = new Map([

--- a/src/index.browser.ts
+++ b/src/index.browser.ts
@@ -24,7 +24,7 @@ export function createHmac(alg: string, key: string | Buffer): Hmac {
     return new Hmac(alg.toLowerCase(), key);
 }
 
-const nativeFetch = fetch;
+const nativeFetch = fetch.bind(window);
 const nativeWS = WebSocket;
 
 const nativeRTCPeerConnection: RTCPeerConnection | undefined = root.RTCPeerConnection;


### PR DESCRIPTION
In Stanza, the `getHostMeta` function in  `plugins/hostmeta.ts` has been failing with the error `'fetch' called on an object that does not implement interface Window` when Stanza is imported from a project bundled via Webpack 5.52.1.

Fetch is now simply bound to `window`, which resolves the problem.