### PR TITLE
Use self instead of window for web workers in fetch bind

### DIFF
--- a/dist/index.browser-module.js
+++ b/dist/index.browser-module.js
@@ -916,6 +916,9 @@ let root;
 if (typeof window !== 'undefined') {
     root = window;
 }
+else if (typeof self !== 'undefined') {
+    root = self;
+}
 else if (typeof global !== 'undefined') {
     root = global;
 }
@@ -932,7 +935,7 @@ function getHashes() {
 function createHmac(alg, key) {
     return new Hmac(alg.toLowerCase(), key);
 }
-const nativeFetch = fetch.bind(window);
+const nativeFetch = fetch.bind(root);
 const nativeWS = WebSocket;
 const nativeRTCPeerConnection = root.RTCPeerConnection;
 

--- a/dist/index.browser.js
+++ b/dist/index.browser.js
@@ -10,6 +10,9 @@ let root;
 if (typeof window !== 'undefined') {
     root = window;
 }
+else if (typeof self !== 'undefined') {
+    root = self;
+}
 else if (typeof global !== 'undefined') {
     root = global;
 }
@@ -29,7 +32,7 @@ function createHmac(alg, key) {
     return new Hmac_1.default(alg.toLowerCase(), key);
 }
 exports.createHmac = createHmac;
-const nativeFetch = fetch.bind(window);
+const nativeFetch = fetch.bind(root);
 exports.fetch = nativeFetch;
 const nativeWS = WebSocket;
 exports.WebSocket = nativeWS;

--- a/package.json
+++ b/package.json
@@ -1,50 +1,50 @@
 {
-  "name": "stanza-shims",
-  "description": "Runtime shims used by StanzaJS for node, browsers, and React Native",
-  "version": "1.1.2",
-  "author": "Lance Stout <lancestout@gmail.com>",
-  "browser": "./dist/index.browser-module.js",
-  "bugs": "https://github.com/legastero/stanza/issues",
-  "dependencies": {
-    "@types/readable-stream": "^2.3.4",
-    "@types/ws": "^6.0.3",
-    "node-fetch": "^2.6.0",
-    "react-native-randombytes": "^3.5.3",
-    "readable-stream": "^2.3.6",
-    "tslib": "^1.10.0",
-    "ws": "^7.1.2"
-  },
-  "devDependencies": {
-    "husky": "^3.0.8",
-    "prettier": "^1.18.2",
-    "pretty-quick": "^1.11.1",
-    "rimraf": "^3.0.0",
-    "rollup": "^1.22.0",
-    "rollup-plugin-node-resolve": "^5.2.0",
-    "typescript": "^3.6.3"
-  },
-  "homepage": "https://stanzajs.org",
-  "husky": {
-    "hooks": {
-      "pre-commit": "pretty-quick --stage"
-    }
-  },
-  "license": "MIT",
-  "main": "./dist/index.node.js",
-  "prettier": {
-    "tabWidth": 4,
-    "printWidth": 100,
-    "semi": true,
-    "singleQuote": true
-  },
-  "react-native": "./dist/index.react-native.js",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/legastero/stanza-shims"
-  },
-  "scripts": {
-    "build": "rimraf ./dist && tsc -p . && tsc -p . --module es2015 --outDir ./dist/es && rollup -c rollup.config.js && rimraf ./dist/es"
-  },
-  "sideEffects": false,
-  "typings": "./dist/index.browser.d.ts"
+    "name": "stanza-shims",
+    "description": "Runtime shims used by StanzaJS for node, browsers, and React Native",
+    "version": "1.1.3",
+    "author": "Lance Stout <lancestout@gmail.com>",
+    "browser": "./dist/index.browser-module.js",
+    "bugs": "https://github.com/legastero/stanza/issues",
+    "dependencies": {
+        "@types/readable-stream": "^2.3.4",
+        "@types/ws": "^6.0.3",
+        "node-fetch": "^2.6.0",
+        "react-native-randombytes": "^3.5.3",
+        "readable-stream": "^2.3.6",
+        "tslib": "^1.10.0",
+        "ws": "^7.1.2"
+    },
+    "devDependencies": {
+        "husky": "^3.0.8",
+        "prettier": "^1.18.2",
+        "pretty-quick": "^1.11.1",
+        "rimraf": "^3.0.0",
+        "rollup": "^1.22.0",
+        "rollup-plugin-node-resolve": "^5.2.0",
+        "typescript": "^3.6.3"
+    },
+    "homepage": "https://stanzajs.org",
+    "husky": {
+        "hooks": {
+            "pre-commit": "pretty-quick --stage"
+        }
+    },
+    "license": "MIT",
+    "main": "./dist/index.node.js",
+    "prettier": {
+        "tabWidth": 4,
+        "printWidth": 100,
+        "semi": true,
+        "singleQuote": true
+    },
+    "react-native": "./dist/index.react-native.js",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/legastero/stanza-shims"
+    },
+    "scripts": {
+        "build": "rimraf ./dist && tsc -p . && tsc -p . --module es2015 --outDir ./dist/es && rollup -c rollup.config.js && rimraf ./dist/es"
+    },
+    "sideEffects": false,
+    "typings": "./dist/index.browser.d.ts"
 }

--- a/src/index.browser.ts
+++ b/src/index.browser.ts
@@ -4,6 +4,8 @@ import Hmac from './crypto/Hmac';
 let root: any;
 if (typeof window !== 'undefined') {
     root = window;
+} else if (typeof self !== 'undefined') {
+    root = self;
 } else if (typeof global !== 'undefined') {
     root = global;
 }
@@ -24,7 +26,7 @@ export function createHmac(alg: string, key: string | Buffer): Hmac {
     return new Hmac(alg.toLowerCase(), key);
 }
 
-const nativeFetch = fetch.bind(window);
+const nativeFetch = fetch.bind(root);
 const nativeWS = WebSocket;
 
 const nativeRTCPeerConnection: RTCPeerConnection | undefined = root.RTCPeerConnection;


### PR DESCRIPTION
Binding `fetch` explicitly to `window` will fail when Stanza is used in a web worker. Binding instead to root, and therefore window/self/global where each are proper, will work in all environments.